### PR TITLE
Fix portfolio renderer scope

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
+(() => {
 const { twinBlocks, projects, publications, capabilities } = window.portfolioData;
 
 const $ = (selector, root = document) => root.querySelector(selector);
@@ -77,3 +78,4 @@ if ('serviceWorker' in navigator) {
     if ('caches' in window) (await caches.keys()).forEach((key) => caches.delete(key));
   });
 }
+})();


### PR DESCRIPTION
## What changed

Wraps the portfolio renderer in an isolated function scope so it can safely consume the classic `data.js` globals without redeclaring `twinBlocks`, `projects`, `publications`, or `capabilities`.

## Impact

Restores dynamic project cards, the searchable project archive, publications, capability groups, Twin layer controls, field-block telemetry updates, mobile navigation behavior, and legacy service-worker cleanup.

## Validation

- Local JavaScript syntax check passed.
- Uploaded content blob SHA `f7b6836faf7fcf1bd22bc75cb61d7f9d7dc3d81e` matches the local Git blob hash.
- This PR changes only `script.js`.